### PR TITLE
1.0.0 => 1.1.0 for dependency bound changes

### DIFF
--- a/fswait.cabal
+++ b/fswait.cabal
@@ -1,5 +1,5 @@
 name:                fswait
-version:             1.0.0
+version:             1.1.0
 synopsis:            Wait and observe events on the filesystem for a path, with a timeout
 homepage:            https://github.com/ixmatus/fswait
 Bug-Reports:         https://github.com/ixmatus/fswait/issues

--- a/nix/optparse-applicative.nix
+++ b/nix/optparse-applicative.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "optparse-applicative";
+  version = "0.14.0.0";
+  sha256 = "06iwp1qsq0gjhnhxwyhdhldwvhlgcik6lx5jxpbb40fispyk4nxm";
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
+  homepage = "https://github.com/pcapriotti/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/turtle.nix
+++ b/nix/turtle.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
+, directory, doctest, foldl, hostname, managed, optional-args
+, optparse-applicative, process, semigroups, stdenv, stm
+, system-fileio, system-filepath, temporary, text, time
+, transformers, unix, unix-compat
+}:
+mkDerivation {
+  pname = "turtle";
+  version = "1.3.6";
+  sha256 = "0fr8p6rnk2lrsgbfh60jlqcjr0nxrh3ywxsj5d4psck0kgyhvg1m";
+  libraryHaskellDepends = [
+    ansi-wl-pprint async base bytestring clock directory foldl hostname
+    managed optional-args optparse-applicative process semigroups stm
+    system-fileio system-filepath temporary text time transformers unix
+    unix-compat
+  ];
+  testHaskellDepends = [ base doctest system-filepath temporary ];
+  description = "Shell programming, Haskell-style";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -5,6 +5,10 @@ let
         overrides = haskellPackagesNew: haskellPackagesOld: {
           optparse-generic =
             haskellPackagesNew.callPackage ./nix/optparse-generic.nix { };
+          optparse-applicative =
+            haskellPackagesNew.callPackage ./nix/optparse-applicative.nix { };
+          turtle =
+            haskellPackagesNew.callPackage ./nix/turtle.nix { };
           fswait =
             haskellPackagesNew.callPackage ./default.nix { };
         };


### PR DESCRIPTION
This change bumps the minor version in response to the updated dependency bounds. Two new Nix derivations have also been added so that `nix-build --attr fswait release.nix` works.