### PR TITLE
Update dependency bounds

### DIFF
--- a/fswait.cabal
+++ b/fswait.cabal
@@ -11,7 +11,7 @@ copyright:           2017 Parnell Springmeyer
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
-Tested-With:         GHC == 7.10.2, GHC == 8.0.1
+Tested-With:         GHC == 7.10.2, GHC == 8.0.1, GHC == 8.10.7
 Category:            Tools
 Description:
     @fswait@ is a utility for blocking on the observation of a

--- a/fswait.cabal
+++ b/fswait.cabal
@@ -36,7 +36,7 @@ executable fswait
               , system-filepath      >= 0.3.1   && < 0.5
               , turtle               >= 1.3.0   && < 1.4
               , time-units           >= 1.0.0   && < 2.0
-              , stm                  >= 2.4.4.1 && < 2.5
+              , stm                  >= 2.4.4.1 && < 2.6
               -- `hinotify` introduced a breaking change in `0.3.10` by
               -- using `RawFilePath` instead of `FilePath`
               , hinotify             >= 0.3     && < 0.3.10

--- a/fswait.cabal
+++ b/fswait.cabal
@@ -40,7 +40,6 @@ executable fswait
               -- `hinotify` introduced a breaking change in `0.3.10` by
               -- using `RawFilePath` instead of `FilePath`
               , hinotify             >= 0.3     && < 0.3.10
-              , semigroups           >= 0.18    && < 0.19
               , text                 >= 0.11    && < 1.3
 
   hs-source-dirs:      src

--- a/fswait.cabal
+++ b/fswait.cabal
@@ -37,9 +37,7 @@ executable fswait
               , turtle               >= 1.3.0   && < 1.6
               , time-units           >= 1.0.0   && < 2.0
               , stm                  >= 2.4.4.1 && < 2.6
-              -- `hinotify` introduced a breaking change in `0.3.10` by
-              -- using `RawFilePath` instead of `FilePath`
-              , hinotify             >= 0.3     && < 0.3.10
+              , hinotify             >= 0.3     && < 0.5
               , text                 >= 0.11    && < 1.3
 
   hs-source-dirs:      src

--- a/fswait.cabal
+++ b/fswait.cabal
@@ -31,8 +31,8 @@ executable fswait
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
                 base                 >= 4.8     && < 5
-              , optparse-generic     >= 1.3     && < 1.4
-              , optparse-applicative >= 0.12    && < 0.15
+              , optparse-generic     >= 1.4     && < 1.5
+              , optparse-applicative
               , system-filepath      >= 0.3.1   && < 0.5
               , turtle               >= 1.3.0   && < 1.6
               , time-units           >= 1.0.0   && < 2.0

--- a/fswait.cabal
+++ b/fswait.cabal
@@ -34,7 +34,7 @@ executable fswait
               , optparse-generic     >= 1.3     && < 1.4
               , optparse-applicative >= 0.12    && < 0.15
               , system-filepath      >= 0.3.1   && < 0.5
-              , turtle               >= 1.3.0   && < 1.4
+              , turtle               >= 1.3.0   && < 1.6
               , time-units           >= 1.0.0   && < 2.0
               , stm                  >= 2.4.4.1 && < 2.6
               -- `hinotify` introduced a breaking change in `0.3.10` by

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -20,6 +20,7 @@ import           Data.List.NonEmpty           (NonEmpty)
 import qualified Data.List.NonEmpty           as NonEmpty
 import           Data.Maybe                   (fromMaybe)
 import           Data.Monoid                  ((<>))
+import           Data.String                  (fromString)
 import qualified Data.Text                    as Text
 import qualified Data.Time.Units              as Time.Units
 import qualified Filesystem.Path              as Path
@@ -101,8 +102,8 @@ main = do
   mvar <- STM.atomically TMVar.newEmptyTMVar
 
   let eventSet  = NonEmpty.toList (NonEmpty.nub events)
-  let watchdir  = Path.encodeString (Path.directory path)
-  let watchfile = Path.encodeString (Path.filename path)
+  let watchdir  = fromString (Path.encodeString (Path.directory path))
+  let watchfile = fromString (Path.encodeString (Path.filename path))
   let timeout'  = fromMaybe (Time.Units.fromMicroseconds (120 * μ)) timeout
   let eventsStr = Text.unwords $ fmap (Text.pack . show) eventSet
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -46,13 +46,13 @@ instance ParseRecord Time.Units.Second where
   parseRecord = fmap getOnly parseRecord
 instance ParseFields Time.Units.Second
 instance ParseField Time.Units.Second where
-  parseField h n c =
+  parseField help long short _value =
     fmap (Time.Units.fromMicroseconds . (*μ))
       (Options.option Options.auto $
        (  Options.metavar "Seconds"
-       <> foldMap  Options.short               c
-       <> foldMap (Options.long . Text.unpack) n
-       <> foldMap (Options.help . Text.unpack) h
+       <> foldMap  Options.short               short
+       <> foldMap (Options.long . Text.unpack) long
+       <> foldMap (Options.help . Text.unpack) help
        )
       )
 
@@ -62,7 +62,7 @@ instance ParseRecord EventVariety where
   parseRecord = fmap getOnly parseRecord
 instance ParseFields EventVariety
 instance ParseField EventVariety where
-  parseField _ _ _ =
+  parseField _help _long _short _value =
         Options.flag' Access       (Options.long "access")
     <|> Options.flag' Modify       (Options.long "modify")
     <|> Options.flag' Attrib       (Options.long "attrib")


### PR DESCRIPTION
`fswait` was failing to build with the WIP Nixpkgs 20.09 upgrade due to the old version of `hinotify`.

Commits are atomic.